### PR TITLE
Update client.go

### DIFF
--- a/client.go
+++ b/client.go
@@ -80,8 +80,8 @@ func (c *Client) updateCache() error {
 	return nil
 }
 
-func fetchJWKs(origin string) ([]jose.JsonWebKey, error) {
-	var ks jose.JsonWebKeySet
+func fetchJWKs(origin string) ([]jose.JSONWebKey, error) {
+	var ks jose.JSONWebKeySet
 
 	resp, err := httpClient.Get(origin)
 	if err != nil {


### PR DESCRIPTION
When using the `dep` tool for package management, then Go will stumble on these properties 'that do not exist' in de vendor libraries dep pulls in. I updated the names of these variables that DO exists in the referenced library that the `dep` tool has pulled in